### PR TITLE
Update gperftools version from 2.5 to 2.7

### DIFF
--- a/third_party/download_and_patch_prerequisites.sh
+++ b/third_party/download_and_patch_prerequisites.sh
@@ -57,7 +57,7 @@ third_party_lib_urls=("https://github.com/google/benchmark/archive/v1.3.0.tar.gz
                       "https://github.com/google/googletest/archive/release-1.8.0.tar.gz"
                       "https://github.com/antirez/linenoise/archive/1.0.tar.gz"
                       "https://github.com/google/re2/archive/2017-01-01.tar.gz"
-                      "https://github.com/gperftools/gperftools/releases/download/gperftools-2.5/gperftools-2.5.tar.gz"
+                      "https://github.com/gperftools/gperftools/releases/download/gperftools-2.7/gperftools-2.7.tar.gz"
                       "https://github.com/google/glog/archive/v0.3.5.tar.gz"
                       )
 
@@ -66,7 +66,7 @@ downloaded_archive_names=("v1.3.0.tar.gz"
                           "release-1.8.0.tar.gz"
                           "1.0.tar.gz"
                           "2017-01-01.tar.gz"
-                          "gperftools-2.5.tar.gz"
+                          "gperftools-2.7.tar.gz"
                           "v0.3.5.tar.gz"
                           )
 


### PR DESCRIPTION
Quickstep build with clang-6 was found to fail under some Ubuntu platforms (by @hassaanirshad for the TRACE project) due to this issue: https://github.com/gperftools/gperftools/issues/946

One safe fix is to upgrade the gperftools version to 2.7 (which is the latest version).