### PR TITLE
Fix Travis CI compile failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@
 # Also, to reduce the total CI time, we explicitly run the most time-consuming
 # build first, using gcc in debug build with joinwithbinaryexpressions.
 
+dist: trusty
+
 language: cpp
 
 cache: ccache
@@ -50,8 +52,8 @@ install:
       export CC="gcc-5";
       export CXX="g++-5";
     elif [ "$CC" = "clang" ]; then
-      export CC="clang-3.7";
-      export CXX="clang++-3.7";
+      export CC="clang-5.0";
+      export CXX="clang++-5.0";
     fi
   - export CLINKER=`which gold`
   - export DEBUG_FLAGS="-g0";
@@ -100,12 +102,11 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.7
-      - george-edison55-precise-backports # For cmake 3.x
+      - llvm-toolchain-trusty-5.0
     packages:
       - gcc-5
       - g++-5
-      - clang-3.7
+      - clang-5.0
       - binutils-gold
       - libprotobuf-dev
       - protobuf-compiler


### PR DESCRIPTION
The current Quickstep master branch is in `failing` status under Travis CI -- the jobs complied with `clang-3.7` have `undefined reference` errors when linking with the `protobuf` library.

The cause might be that the default `libprotobuf-dev` library that we `apt-get` under Travis CI has been upgraded to be built with a later version of `clang` which has [ABI](https://en.wikipedia.org/wiki/Application_binary_interface) changes (e.g. name mangling) so that the `protobuf` symbols cannot be found during linking.

This PR fixes the compilation error by upgrading `clang-3.7` to `clang-5.0` in Travis CI configuration.