### PR TITLE
Fix a bug in the optimization rule that adds FilterJoins.

### DIFF
--- a/cli/LineReader.cpp
+++ b/cli/LineReader.cpp
@@ -222,7 +222,7 @@ std::string LineReader::getNextCommand() {
             // Skip all the whitespaces before the command.
             const std::size_t start_position =
                 multiline_buffer.find_first_not_of(" \t\r\n");
-            DCHECK_LT(start_position, special_char_location + 1);
+            DCHECK_LE(start_position, special_char_location + 1);
             return multiline_buffer.substr(start_position,
                                            special_char_location + 1 - start_position);
           }

--- a/query_optimizer/rules/CMakeLists.txt
+++ b/query_optimizer/rules/CMakeLists.txt
@@ -214,6 +214,7 @@ target_link_libraries(quickstep_queryoptimizer_rules_InjectJoinFilters
                       quickstep_queryoptimizer_physical_PhysicalType
                       quickstep_queryoptimizer_physical_Selection
                       quickstep_queryoptimizer_physical_TopLevelPlan
+                      quickstep_queryoptimizer_rules_CollapseSelection
                       quickstep_queryoptimizer_rules_PruneColumns
                       quickstep_queryoptimizer_rules_Rule
                       quickstep_types_TypeID

--- a/query_optimizer/rules/InjectJoinFilters.hpp
+++ b/query_optimizer/rules/InjectJoinFilters.hpp
@@ -62,7 +62,7 @@ class InjectJoinFilters : public Rule<physical::Physical> {
   ~InjectJoinFilters() override {}
 
   std::string getName() const override {
-    return "TransformFilterJoins";
+    return "InjectJoinFilters";
   }
 
   physical::PhysicalPtr apply(const physical::PhysicalPtr &input) override;

--- a/query_optimizer/tests/CMakeLists.txt
+++ b/query_optimizer/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries(quickstep_queryoptimizer_tests_TestDatabaseLoader
                       quickstep_types_TypedValue
                       quickstep_types_containers_Tuple
                       quickstep_utility_Macros
+                      quickstep_utility_ScopedDeleter
                       tmb)
 if (ENABLE_DISTRIBUTED)
   target_link_libraries(quickstep_queryoptimizer_tests_TestDatabaseLoader
@@ -139,6 +140,7 @@ target_link_libraries(quickstep_queryoptimizer_tests_ExecutionGeneratorTest
                       glog
                       gtest
                       quickstep_catalog_CatalogDatabase
+                      quickstep_cli_CommandExecutor
                       quickstep_cli_DropRelation
                       quickstep_cli_PrintToScreen
                       quickstep_parser_ParseStatement
@@ -148,10 +150,17 @@ target_link_libraries(quickstep_queryoptimizer_tests_ExecutionGeneratorTest
                       quickstep_queryexecution_QueryExecutionUtil
                       quickstep_queryexecution_Worker
                       quickstep_queryexecution_WorkerDirectory
+                      quickstep_queryoptimizer_LogicalGenerator
                       quickstep_queryoptimizer_Optimizer
                       quickstep_queryoptimizer_OptimizerContext
+                      quickstep_queryoptimizer_PhysicalGenerator
                       quickstep_queryoptimizer_QueryHandle
+                      quickstep_queryoptimizer_QueryProcessor
+                      quickstep_queryoptimizer_logical_Logical
+                      quickstep_queryoptimizer_physical_Physical
                       quickstep_queryoptimizer_tests_TestDatabaseLoader
+                      quickstep_storage_StorageConstants
+                      quickstep_storage_StorageManager
                       quickstep_threading_ThreadIDBasedMap
                       quickstep_utility_Macros
                       quickstep_utility_MemStream

--- a/query_optimizer/tests/ExecutionGeneratorTest.cpp
+++ b/query_optimizer/tests/ExecutionGeneratorTest.cpp
@@ -48,8 +48,8 @@ int main(int argc, char** argv) {
           new quickstep::optimizer::ExecutionGeneratorTestRunner(argv[3]));
   test_driver.reset(
       new quickstep::TextBasedTestDriver(&input_file, test_runner.get()));
-  test_driver->registerOption(
-      quickstep::optimizer::ExecutionGeneratorTestRunner::kResetOption);
+  test_driver->registerOptions(
+      quickstep::optimizer::ExecutionGeneratorTestRunner::kTestOptions);
 
   ::testing::InitGoogleTest(&argc, argv);
   int success = RUN_ALL_TESTS();

--- a/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
+++ b/query_optimizer/tests/ExecutionGeneratorTestRunner.cpp
@@ -20,18 +20,30 @@
 #include "query_optimizer/tests/ExecutionGeneratorTestRunner.hpp"
 
 #include <cstdio>
+#include <fstream>
 #include <memory>
 #include <set>
 #include <string>
+#include <vector>
 
+#include "catalog/CatalogDatabase.hpp"
+#include "cli/CommandExecutor.hpp"
 #include "cli/DropRelation.hpp"
 #include "cli/PrintToScreen.hpp"
 #include "parser/ParseStatement.hpp"
 #include "query_execution/ForemanSingleNode.hpp"
 #include "query_execution/QueryExecutionUtil.hpp"
+#include "query_optimizer/LogicalGenerator.hpp"
 #include "query_optimizer/Optimizer.hpp"
 #include "query_optimizer/OptimizerContext.hpp"
+#include "query_optimizer/PhysicalGenerator.hpp"
 #include "query_optimizer/QueryHandle.hpp"
+#include "query_optimizer/QueryProcessor.hpp"
+#include "query_optimizer/logical/Logical.hpp"
+#include "query_optimizer/physical/Physical.hpp"
+#include "query_optimizer/tests/TestDatabaseLoader.hpp"
+#include "storage/StorageConstants.hpp"
+#include "storage/StorageManager.hpp"
 #include "utility/MemStream.hpp"
 #include "utility/SqlError.hpp"
 
@@ -42,9 +54,81 @@ namespace quickstep {
 class CatalogRelation;
 
 namespace optimizer {
+namespace {
 
-const char ExecutionGeneratorTestRunner::kResetOption[] =
-    "reset_before_execution";
+void GenerateAndPrintPhysicalPlan(const ParseStatement &parse_statement,
+                                  CatalogDatabase *catalog_database,
+                                  std::string *output) {
+  OptimizerContext optimizer_context;
+  LogicalGenerator logical_generator(&optimizer_context);
+  PhysicalGenerator physical_generator(&optimizer_context);
+
+  const logical::LogicalPtr logical_plan =
+      logical_generator.generatePlan(*catalog_database, parse_statement);
+  const physical::PhysicalPtr physical_plan =
+      physical_generator.generatePlan(logical_plan, catalog_database);
+  output->append(physical_plan->toString());
+  output->append("--\n");
+}
+
+}  // namespace
+
+const std::vector<std::string> ExecutionGeneratorTestRunner::kTestOptions = {
+    "reset_before_execution", "print_physical_plan",
+};
+
+ExecutionGeneratorTestRunner::ExecutionGeneratorTestRunner(
+    const std::string &storage_path)
+    : storage_manager_(storage_path),
+      thread_id_map_(ClientIDMap::Instance()) {
+  // Create the default catalog file.
+  const std::string catalog_path = storage_path + kCatalogFilename;
+  std::ofstream catalog_file(catalog_path);
+  CHECK(catalog_file.good())
+      << "ERROR: Unable to open " << catalog_path << " for writing.";
+
+  Catalog catalog;
+  catalog.addDatabase(new CatalogDatabase(nullptr, "default"));
+  CHECK(catalog.getProto().SerializeToOstream(&catalog_file))
+      << "ERROR: Unable to serialize catalog proto to file " << storage_path;
+  catalog_file.close();
+
+  // Create query processor and initialize the test database.
+  query_processor_ = std::make_unique<QueryProcessor>(std::string(catalog_path));
+
+  test_database_loader_ = std::make_unique<TestDatabaseLoader>(
+      query_processor_->getDefaultDatabase(), &storage_manager_),
+  test_database_loader_->createTestRelation(false /* allow_vchar */);
+  test_database_loader_->loadTestRelation();
+
+  bus_.Initialize();
+
+  main_thread_client_id_ = bus_.Connect();
+  bus_.RegisterClientAsSender(main_thread_client_id_, kAdmitRequestMessage);
+  bus_.RegisterClientAsSender(main_thread_client_id_, kPoisonMessage);
+  bus_.RegisterClientAsReceiver(main_thread_client_id_, kWorkloadCompletionMessage);
+
+  worker_.reset(new Worker(0, &bus_));
+
+  std::vector<client_id> worker_client_ids;
+  worker_client_ids.push_back(worker_->getBusClientID());
+
+  // We don't use the NUMA aware version of foreman code.
+  std::vector<int> numa_nodes;
+  numa_nodes.push_back(-1);
+
+  workers_.reset(new WorkerDirectory(1 /* number of workers */,
+                                     worker_client_ids, numa_nodes));
+  foreman_.reset(
+      new ForemanSingleNode(main_thread_client_id_,
+                            workers_.get(),
+                            &bus_,
+                            query_processor_->getDefaultDatabase(),
+                            &storage_manager_));
+
+  foreman_->start();
+  worker_->start();
+}
 
 void ExecutionGeneratorTestRunner::runTestCase(
     const std::string &input, const std::set<std::string> &options,
@@ -53,10 +137,10 @@ void ExecutionGeneratorTestRunner::runTestCase(
 
   VLOG(4) << "Test SQL(s): " << input;
 
-  if (options.find(kResetOption) != options.end()) {
-    test_database_loader_.clear();
-    test_database_loader_.createTestRelation(false /* allow_vchar */);
-    test_database_loader_.loadTestRelation();
+  if (options.find(kTestOptions[0]) != options.end()) {
+    test_database_loader_->clear();
+    test_database_loader_->createTestRelation(false /* allow_vchar */);
+    test_database_loader_->loadTestRelation();
   }
 
   MemStream output_stream;
@@ -71,48 +155,64 @@ void ExecutionGeneratorTestRunner::runTestCase(
     ParseResult result = sql_parser_.getNextStatement();
     if (result.condition != ParseResult::kSuccess) {
       if (result.condition == ParseResult::kError) {
-        *output = result.error_message;
+        output->append(result.error_message);
       }
       break;
-    } else {
-      const ParseStatement &parse_statement = *result.parsed_statement;
-      const CatalogRelation *query_result_relation = nullptr;
-      try {
-        OptimizerContext optimizer_context;
-        auto query_handle = std::make_unique<QueryHandle>(0 /* query_id */, main_thread_client_id_);
-
-        optimizer_.generateQueryHandle(parse_statement,
-                                       test_database_loader_.catalog_database(),
-                                       &optimizer_context,
-                                       query_handle.get());
-        query_result_relation = query_handle->getQueryResultRelation();
-
-        QueryExecutionUtil::ConstructAndSendAdmitRequestMessage(
-            main_thread_client_id_,
-            foreman_->getBusClientID(),
-            query_handle.release(),
-            &bus_);
-      } catch (const SqlError &error) {
-        *output = error.formatMessage(input);
-        break;
-      }
-
-      QueryExecutionUtil::ReceiveQueryCompletionMessage(
-          main_thread_client_id_, &bus_);
-
-      if (query_result_relation) {
-        PrintToScreen::PrintRelation(*query_result_relation,
-                                     test_database_loader_.storage_manager(),
-                                     output_stream.file());
-        DropRelation::Drop(*query_result_relation,
-                           test_database_loader_.catalog_database(),
-                           test_database_loader_.storage_manager());
-      }
     }
-  }
 
-  if (output->empty()) {
-    *output = output_stream.str();
+    const ParseStatement &statement = *result.parsed_statement;
+    if (statement.getStatementType() == ParseStatement::kCommand) {
+      try {
+        cli::executeCommand(statement,
+                            *(query_processor_->getDefaultDatabase()),
+                            main_thread_client_id_,
+                            foreman_->getBusClientID(),
+                            &bus_,
+                            &storage_manager_,
+                            query_processor_.get(),
+                            output_stream.file());
+      } catch (const quickstep::SqlError &sql_error) {
+        fprintf(stderr, "%s", sql_error.formatMessage(input).c_str());
+      }
+      output->append(output_stream.str());
+      continue;
+    }
+
+    const CatalogRelation *query_result_relation = nullptr;
+    try {
+      if (options.find(kTestOptions[1]) != options.end()) {
+        GenerateAndPrintPhysicalPlan(statement,
+                                     query_processor_->getDefaultDatabase(),
+                                     output);
+      }
+      auto query_handle = std::make_unique<QueryHandle>(
+          query_processor_->query_id(), main_thread_client_id_);
+
+      query_processor_->generateQueryHandle(statement, query_handle.get());
+      DCHECK(query_handle->getQueryPlanMutable() != nullptr);
+
+      query_result_relation = query_handle->getQueryResultRelation();
+
+      QueryExecutionUtil::ConstructAndSendAdmitRequestMessage(
+          main_thread_client_id_, foreman_->getBusClientID(),
+          query_handle.release(), &bus_);
+    } catch (const SqlError &error) {
+      output->append(error.formatMessage(input));
+      break;
+    }
+
+    QueryExecutionUtil::ReceiveQueryCompletionMessage(main_thread_client_id_,
+                                                      &bus_);
+
+    if (query_result_relation) {
+      PrintToScreen::PrintRelation(*query_result_relation,
+                                   &storage_manager_,
+                                   output_stream.file());
+      DropRelation::Drop(*query_result_relation,
+                         test_database_loader_->catalog_database(),
+                         test_database_loader_->storage_manager());
+    }
+    output->append(output_stream.str());
   }
 }
 

--- a/query_optimizer/tests/execution_generator/CMakeLists.txt
+++ b/query_optimizer/tests/execution_generator/CMakeLists.txt
@@ -60,6 +60,11 @@ add_test(quickstep_queryoptimizer_tests_executiongenerator_join
          "${CMAKE_CURRENT_SOURCE_DIR}/Join.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Join.test"
          "${CMAKE_CURRENT_BINARY_DIR}/Join/")
+add_test(quickstep_queryoptimizer_tests_executiongenerator_lip
+         "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
+         "${CMAKE_CURRENT_SOURCE_DIR}/LIP.test"
+         "${CMAKE_CURRENT_BINARY_DIR}/LIP.test"
+         "${CMAKE_CURRENT_BINARY_DIR}/LIP/")
 add_test(quickstep_queryoptimizer_tests_executiongenerator_partition
          "../quickstep_queryoptimizer_tests_ExecutionGeneratorTest"
          "${CMAKE_CURRENT_SOURCE_DIR}/Partition.test"
@@ -171,6 +176,7 @@ file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Drop)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Index)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Insert)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Join)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/LIP)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Partition)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Select)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/StringPatternMatching)

--- a/query_optimizer/tests/execution_generator/LIP.test
+++ b/query_optimizer/tests/execution_generator/LIP.test
@@ -1,0 +1,151 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Initialize test tables.
+
+CREATE TABLE R(x INT, y INT);
+CREATE TABLE S(z INT);
+
+INSERT INTO R
+SELECT i, i
+FROM generate_series(0, 100000, 2) AS gs(i);
+
+INSERT INTO S
+SELECT i
+FROM generate_series(0, 100000, 3) AS gs(i);
+--
+==
+
+\analyze
+--
+Analyzing Test ... done
+Analyzing R ... done
+Analyzing S ... done
+==
+
+# Tests the Lookahead Information Passing + Exact Filter optimizations.
+
+[default print_physical_plan]
+
+SELECT x FROM R WHERE y IN (SELECT z FROM S) AND x % 10000 = 0;
+--
+TopLevelPlan
++-plan=Selection[has_repartition=false]
+| +-input=FilterJoin[has_repartition=false,is_anti_join=false]
+| | +-left=TableReference[relation=R]
+| | | +-AttributeReference[id=0,name=x,relation=R,type=Int]
+| | | +-AttributeReference[id=1,name=y,relation=R,type=Int]
+| | +-right=TableReference[relation=S]
+| | | +-AttributeReference[id=2,name=z,relation=S,type=Int]
+| | +-project_expressions=
+| | | +-AttributeReference[id=0,name=x,relation=R,type=Int]
+| | +-probe_attributes=
+| | | +-AttributeReference[id=1,name=y,relation=R,type=Int]
+| | +-build_attributes=
+| |   +-AttributeReference[id=2,name=z,relation=S,type=Int]
+| +-filter_predicate=Equal
+| | +-Modulo
+| | | +-AttributeReference[id=0,name=x,relation=R,type=Int]
+| | | +-Literal[value=10000,type=Int]
+| | +-Literal[value=0,type=Int]
+| +-project_expressions=
+|   +-AttributeReference[id=0,name=x,relation=R,type=Int]
++-output_attributes=
+  +-AttributeReference[id=0,name=x,relation=R,type=Int]
+--
++-----------+
+|x          |
++-----------+
+|          0|
+|      30000|
+|      60000|
+|      90000|
++-----------+
+==
+
+SELECT SUM(x)
+FROM (
+  SELECT x FROM R WHERE y IN (SELECT z FROM S) AND x % 5 = 0
+  UNION ALL
+  SELECT x FROM R WHERE y IN (SELECT z FROM S) AND x % 7 = 0
+) t;
+--
+TopLevelPlan
++-plan=Selection[has_repartition=false]
+| +-input=Aggregate[has_repartition=false]
+| | +-input=UnionAll
+| | | +-operands=
+| | | | +-Selection[has_repartition=false]
+| | | | | +-input=FilterJoin[has_repartition=false,is_anti_join=false]
+| | | | | | +-left=TableReference[relation=R]
+| | | | | | | +-AttributeReference[id=0,name=x,relation=R,type=Int]
+| | | | | | | +-AttributeReference[id=1,name=y,relation=R,type=Int]
+| | | | | | +-right=TableReference[relation=S]
+| | | | | | | +-AttributeReference[id=2,name=z,relation=S,type=Int]
+| | | | | | +-project_expressions=
+| | | | | | | +-AttributeReference[id=0,name=x,relation=R,type=Int]
+| | | | | | +-probe_attributes=
+| | | | | | | +-AttributeReference[id=1,name=y,relation=R,type=Int]
+| | | | | | +-build_attributes=
+| | | | | |   +-AttributeReference[id=2,name=z,relation=S,type=Int]
+| | | | | +-filter_predicate=Equal
+| | | | | | +-Modulo
+| | | | | | | +-AttributeReference[id=0,name=x,relation=R,type=Int]
+| | | | | | | +-Literal[value=5,type=Int]
+| | | | | | +-Literal[value=0,type=Int]
+| | | | | +-project_expressions=
+| | | | |   +-AttributeReference[id=0,name=x,relation=R,type=Int]
+| | | | +-Selection[has_repartition=false]
+| | | |   +-input=FilterJoin[has_repartition=false,is_anti_join=false]
+| | | |   | +-left=TableReference[relation=R]
+| | | |   | | +-AttributeReference[id=3,name=x,relation=R,type=Int]
+| | | |   | | +-AttributeReference[id=4,name=y,relation=R,type=Int]
+| | | |   | +-right=TableReference[relation=S]
+| | | |   | | +-AttributeReference[id=5,name=z,relation=S,type=Int]
+| | | |   | +-project_expressions=
+| | | |   | | +-AttributeReference[id=3,name=x,relation=R,type=Int]
+| | | |   | +-probe_attributes=
+| | | |   | | +-AttributeReference[id=4,name=y,relation=R,type=Int]
+| | | |   | +-build_attributes=
+| | | |   |   +-AttributeReference[id=5,name=z,relation=S,type=Int]
+| | | |   +-filter_predicate=Equal
+| | | |   | +-Modulo
+| | | |   | | +-AttributeReference[id=3,name=x,relation=R,type=Int]
+| | | |   | | +-Literal[value=7,type=Int]
+| | | |   | +-Literal[value=0,type=Int]
+| | | |   +-project_expressions=
+| | | |     +-AttributeReference[id=3,name=x,relation=R,type=Int]
+| | | +-project_attributes=
+| | |   +-AttributeReference[id=6,name=x,relation=,type=Int]
+| | +-grouping_expressions=
+| | | +-[]
+| | +-aggregate_expressions=
+| |   +-Alias[id=7,name=,alias=$aggregate0,relation=$aggregate,type=Long NULL]
+| |     +-AggregateFunction[function=SUM]
+| |       +-AttributeReference[id=6,name=x,relation=,type=Int]
+| +-project_expressions=
+|   +-Alias[id=7,name=,alias=SUM(x),relation=,type=Long NULL]
+|     +-AttributeReference[id=7,name=,alias=$aggregate0,relation=$aggregate,
+|       type=Long NULL]
++-output_attributes=
+  +-AttributeReference[id=7,name=,alias=SUM(x),relation=,type=Long NULL]
+--
++--------------------+
+|SUM(x)              |
++--------------------+
+|           285685710|
++--------------------+

--- a/utility/ScopedDeleter.hpp
+++ b/utility/ScopedDeleter.hpp
@@ -64,6 +64,19 @@ class ScopedDeleter {
   }
 
   /**
+   * @brief Create an object and add it to the pool of objects to be deleted by
+   *        this ScopedDeleter.
+   *
+   * @param arguments Forwarded varadic arguments for constructing the object.
+   **/
+  template <typename T, typename ...ArgTypes>
+  inline T* createObject(ArgTypes &&...arguments) {
+    T* object = new T(std::forward<ArgTypes>(arguments)...);
+    objects_.emplace_back(&DeleteObject<T>, object);
+    return object;
+  }
+
+  /**
    * @brief Delete all objects held by this ScopedDeleter without destroying
    *        it.
    **/

--- a/utility/tests/ScopedDeleter_unittest.cpp
+++ b/utility/tests/ScopedDeleter_unittest.cpp
@@ -91,14 +91,18 @@ TEST(ScopedDeleterTest, DeletionTest) {
   bool base_1_deleted, base_2_deleted,
        derived_a_1_base_deleted, derived_a_1_derived_deleted,
        derived_a_2_base_deleted, derived_a_2_derived_deleted,
+       derived_a_3_base_deleted, derived_a_3_derived_deleted,
        derived_b_1_base_deleted, derived_b_1_derived_deleted,
        derived_b_2_base_deleted, derived_b_2_derived_deleted,
+       derived_b_3_base_deleted, derived_b_3_derived_deleted,
        other_1_deleted, other_2_deleted;
   base_1_deleted = base_2_deleted
       = derived_a_1_base_deleted = derived_a_1_derived_deleted
       = derived_a_2_base_deleted = derived_a_2_derived_deleted
+      = derived_a_3_base_deleted = derived_a_3_derived_deleted
       = derived_b_1_base_deleted = derived_b_1_derived_deleted
       = derived_b_2_base_deleted = derived_b_2_derived_deleted
+      = derived_b_3_base_deleted = derived_b_3_derived_deleted
       = other_1_deleted = other_2_deleted
       = false;
 
@@ -106,7 +110,7 @@ TEST(ScopedDeleterTest, DeletionTest) {
   ScopedDeleter deleter;
 
   deleter.addObject(new Base(&base_1_deleted));
-  deleter.addObject(new Base(&base_2_deleted));
+  deleter.createObject<Base>(&base_2_deleted);
 
   // Add one instance of DerivedA as itself, and one as a Base class pointer.
   deleter.addObject(new DerivedA(&derived_a_1_base_deleted,
@@ -114,6 +118,9 @@ TEST(ScopedDeleterTest, DeletionTest) {
   Base *derived_a_2 = new DerivedA(&derived_a_2_base_deleted,
                                    &derived_a_2_derived_deleted);
   deleter.addObject(derived_a_2);
+  // One more for testing 'createObject'.
+  deleter.createObject<DerivedA>(&derived_a_3_base_deleted,
+                                 &derived_a_3_derived_deleted);
 
   // Do the same for the other derived class.
   deleter.addObject(new DerivedB(&derived_b_1_base_deleted,
@@ -121,16 +128,21 @@ TEST(ScopedDeleterTest, DeletionTest) {
   Base *derived_b_2 = new DerivedB(&derived_b_2_base_deleted,
                                    &derived_b_2_derived_deleted);
   deleter.addObject(derived_b_2);
+  // One more for testing 'createObject'.
+  deleter.createObject<DerivedB>(&derived_b_3_base_deleted,
+                                 &derived_b_3_derived_deleted);
 
   // Also throw in a couple of objects that aren't part of the same inheritance
   // heirarchy.
   deleter.addObject(new Other(&other_1_deleted));
-  deleter.addObject(new Other(&other_2_deleted));
+  deleter.createObject<Other>(&other_2_deleted);
 
   // Add some heap-allocated built-in types (we don't directly check whether
   // these are deleted, but running under valgrind should report no leaks).
   deleter.addObject(new int);
   deleter.addObject(new float);
+  deleter.createObject<int>();
+  deleter.createObject<float>();
 
   // Have the deleter delete everything and verify that destructors were
   // invoked.
@@ -142,10 +154,14 @@ TEST(ScopedDeleterTest, DeletionTest) {
   EXPECT_TRUE(derived_a_1_derived_deleted);
   EXPECT_TRUE(derived_a_2_base_deleted);
   EXPECT_TRUE(derived_a_2_derived_deleted);
+  EXPECT_TRUE(derived_a_3_base_deleted);
+  EXPECT_TRUE(derived_a_3_derived_deleted);
   EXPECT_TRUE(derived_b_1_base_deleted);
   EXPECT_TRUE(derived_b_1_derived_deleted);
   EXPECT_TRUE(derived_b_2_base_deleted);
   EXPECT_TRUE(derived_b_2_derived_deleted);
+  EXPECT_TRUE(derived_b_3_base_deleted);
+  EXPECT_TRUE(derived_b_3_derived_deleted);
   EXPECT_TRUE(other_1_deleted);
   EXPECT_TRUE(other_2_deleted);
 


### PR DESCRIPTION
The bug is that after pushing down FilterJoin nodes the output attributes may be changed, and this causes problems for some nodes (e.g. UnionAll).

Also updated execution query tests to support executing commands (e.g. `\analyze`) and testing LIP.

The context of this PR is to merge the `trace-dev` branch into `master` (#1).