### PR TITLE
Add missing comma causing implicit str concat

### DIFF
--- a/expressions/scalar/Scalar.cpp
+++ b/expressions/scalar/Scalar.cpp
@@ -31,7 +31,7 @@ const char *Scalar::kScalarDataSourceNames[] = {
   "Attribute",
   "UnaryExpression",
   "BinaryExpression",
-  "SimpleCase"
+  "SimpleCase",
   "SharedExpression",
 };
 


### PR DESCRIPTION
This was found with a regex and is most likely a bug. The two strings get concatenated into one, which would break both.