### PR TITLE
feat(compile): revive quickstep with support for clang-14

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,16 +1,17 @@
 # Quickstep Build Guide
 
 **Contents**
-* [Basic Instructions](#basic-instructions)
-  * [Prerequisites](#prerequisites)
-  * [Building](#building)
-  * [Running Quickstep](#running-quickstep)
-  * [Running Tests](#running-tests)
-  * [Configuring with CMake](#configuring-with-cmake)
-* [Advanced Configuration](#advanced-configuration)
-* [Appendix](#appendix)
-  * [Building on Windows](#building-on-windows)
-  * [Building in Vagrant](#building-in-vagrant)
+- [Quickstep Build Guide](#quickstep-build-guide)
+- [Basic Instructions](#basic-instructions)
+  - [Prerequisites](#prerequisites)
+  - [Building](#building)
+  - [Running Quickstep](#running-quickstep)
+  - [Running Tests](#running-tests)
+  - [Configuring with CMake](#configuring-with-cmake)
+- [Advanced Configuration](#advanced-configuration)
+- [Appendix](#appendix)
+  - [Building on Windows](#building-on-windows)
+  - [Building in Vagrant](#building-in-vagrant)
 
 
 **Short Version**
@@ -22,7 +23,9 @@ cd third_party
 ./download_and_patch_prerequisites.sh
 cd ../build
 cmake ..
-make quickstep_cli_shell
+# Please note that the first compilation may take a long time due to template instantiations especially for meta programming
+make quickstep_cli_shell -j`nproc`
+# Only for the first run to initialize the empty `catalog`
 ./quickstep_cli_shell -initialize_db=true
 ```
 
@@ -30,11 +33,17 @@ make quickstep_cli_shell
 
 ## Prerequisites
 
-- C++ compiler that supports the C++14 standard (GCC 4.9+ or Clang 3.4+ are good)
+- C++ compiler that supports the C++17 standard (GCC 4.9+ or Clang 3.4+ are good)
 - [cmake](http://www.cmake.org/download/) 2.8.6+
 - curl
 
 All these programs should be available on your distro's package manager.
+
+**Recommended**
+
+Strange errors could occur with `GCC`, and we're not currently upgrade this part to satisfy it.
+
+- Clang 14.0.0 (Or any other clang version that supports C++17)
 
 **Optional**
 
@@ -76,7 +85,7 @@ running cmake.
 
 Like a conventional configure script, you can configure some settings about how
 quickstep is built when you invoke cmake. The most important is the build type.
-You can build an unoptimized build with debugging information by doing:
+You can build an not optimized build with debugging information by doing:
 
 ```
 cmake -D CMAKE_BUILD_TYPE=Debug ..
@@ -86,6 +95,12 @@ You can build a fast, optimized release build by doing:
 
 ```
 cmake -D CMAKE_BUILD_TYPE=Release ..
+```
+
+If you're using a linux distribution and want to utilize `clang` for compilation (which is recommended), run the cmake command by doing:
+
+```
+cmake -D CMAKE_C_COMPILER=/path/to/clang -D CMAKE_CXX_COMPILER=/path/to/clang++ /** other configurations */ ..
 ```
 
 The first time you check out the Quickstep source repo, you will also need to

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,14 @@ project (QUICKSTEP)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# TODO: Resolve these, now we simply suppress the warnings as temporary solution
+add_compile_options(-Wno-deprecated-declarations)
+add_compile_options(-Wno-unused-but-set-variable)
+
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 include(CheckCXXSourceCompiles)

--- a/expressions/ExpressionFactories.cpp
+++ b/expressions/ExpressionFactories.cpp
@@ -63,9 +63,9 @@ Predicate* PredicateFactory::ReconstructFromProto(const serialization::Predicate
       << proto.DebugString();
 
   switch (proto.predicate_type()) {
-    case serialization::Predicate::TRUE:
+    case serialization::Predicate_PredicateType_TRUE:
       return new TruePredicate();
-    case serialization::Predicate::FALSE:
+    case serialization::Predicate_PredicateType_FALSE:
       return new FalsePredicate();
     case serialization::Predicate::COMPARISON:
       return new ComparisonPredicate(
@@ -111,8 +111,8 @@ bool PredicateFactory::ProtoIsValid(const serialization::Predicate &proto,
 
   // Check that the predicate_type is valid, and extensions if any.
   switch (proto.predicate_type()) {
-    case serialization::Predicate::TRUE:  // Fall through.
-    case serialization::Predicate::FALSE:
+    case serialization::Predicate_PredicateType_TRUE:  // Fall through.
+    case serialization::Predicate_PredicateType_FALSE:
       return true;
     case serialization::Predicate::COMPARISON: {
       if (proto.HasExtension(serialization::ComparisonPredicate::comparison)

--- a/expressions/predicate/TrivialPredicates.hpp
+++ b/expressions/predicate/TrivialPredicates.hpp
@@ -64,7 +64,7 @@ class TruePredicate : public TrivialPredicate {
 
   serialization::Predicate getProto() const override {
     serialization::Predicate proto;
-    proto.set_predicate_type(serialization::Predicate::TRUE);
+    proto.set_predicate_type(serialization::Predicate_PredicateType_TRUE);
 
     return proto;
   }
@@ -115,7 +115,7 @@ class FalsePredicate : public TrivialPredicate {
 
   serialization::Predicate getProto() const override {
     serialization::Predicate proto;
-    proto.set_predicate_type(serialization::Predicate::FALSE);
+    proto.set_predicate_type(serialization::Predicate_PredicateType_FALSE);
 
     return proto;
   }

--- a/query_execution/QueryManagerBase.cpp
+++ b/query_execution/QueryManagerBase.cpp
@@ -72,7 +72,7 @@ QueryManagerBase::QueryManagerBase(QueryHandle *query_handle)
       non_dependent_operators_.push_back(node_index);
     }
 
-    for (const pair<dag_node_index, bool> &dependent_link :
+    for (const auto &dependent_link :
          query_dag_->getDependents(node_index)) {
       const dag_node_index dependent_op_index = dependent_link.first;
       if (query_dag_->getLinkMetadata(node_index, dependent_op_index)) {
@@ -185,7 +185,7 @@ void QueryManagerBase::markOperatorFinished(const dag_node_index index) {
 
   const relation_id output_rel = op->getOutputRelationID();
 
-  for (const pair<dag_node_index, bool> &dependent_link : query_dag_->getDependents(index)) {
+  for (const auto &dependent_link : query_dag_->getDependents(index)) {
     const dag_node_index dependent_op_index = dependent_link.first;
     if (output_rel >= 0) {
       // Signal dependent operator that current operator is done feeding input blocks.

--- a/query_optimizer/ExecutionGenerator.cpp
+++ b/query_optimizer/ExecutionGenerator.cpp
@@ -536,7 +536,7 @@ void ExecutionGenerator::createTemporaryCatalogRelation(
   }
 
   attribute_id aid = 0;
-  for (const E::NamedExpressionPtr &project_expression :
+  for (const auto &project_expression :
        physical->getOutputAttributes()) {
     // The attribute name is simply set to the attribute id to make it distinct.
     auto catalog_attribute =
@@ -1165,7 +1165,7 @@ void ExecutionGenerator::convertNestedLoopsJoin(
         convertPredicate(physical_plan->join_predicate(), left_expr_ids, right_expr_ids));
     query_context_proto_->add_predicates()->MergeFrom(execution_join_predicate->getProto());
   } else {
-    query_context_proto_->add_predicates()->set_predicate_type(S::Predicate::TRUE);
+    query_context_proto_->add_predicates()->set_predicate_type(S::Predicate_PredicateType_TRUE);
   }
 
   // Convert the project expressions proto.
@@ -2420,7 +2420,7 @@ void ExecutionGenerator::convertWindowAggregate(
 
   // Set partition keys.
   const E::WindowInfo &window_info = window_aggregate_function->window_info();
-  for (const E::ScalarPtr &partition_by_attribute
+  for (const auto &partition_by_attribute
       : window_info.partition_by_attributes) {
     unique_ptr<const Scalar> concretized_partition_by_attribute(
         partition_by_attribute->concretize(attribute_substitution_map_));
@@ -2429,7 +2429,7 @@ void ExecutionGenerator::convertWindowAggregate(
   }
 
   // Set order keys.
-  for (const E::ScalarPtr &order_by_attribute
+  for (const auto &order_by_attribute
       : window_info.order_by_attributes) {
     unique_ptr<const Scalar> concretized_order_by_attribute(
         order_by_attribute->concretize(attribute_substitution_map_));

--- a/storage/SplitRowStoreTupleStorageSubBlock.cpp
+++ b/storage/SplitRowStoreTupleStorageSubBlock.cpp
@@ -380,8 +380,7 @@ tuple_id SplitRowStoreTupleStorageSubBlock::bulkInsertPartialTuplesImpl(
             const VarLenAttr &vattr = varlen_attrs[vattr_idx];
             attr_cursor += vattr.bytes_to_advance;
             // Typed value is necessary as we need the length.
-            const TypedValue &attr_value =
-                accessor->template getTypedValue(vattr.src_attr_id);
+            const TypedValue &attr_value = accessor->getTypedValue(vattr.src_attr_id);
             if (attr_value.isNull()) {
               continue;
             }


### PR DESCRIPTION
As titled, now we could directly compile `quickstep` in any linux distros / macOS with `clang`.